### PR TITLE
A fix with octal literal string encoding, and rewritten pdfname encod…

### DIFF
--- a/src/Synercoding.FileFormats.Pdf/LowLevel/Extensions/PdfStreamExtensions.cs
+++ b/src/Synercoding.FileFormats.Pdf/LowLevel/Extensions/PdfStreamExtensions.cs
@@ -255,8 +255,16 @@ public static class PdfStreamExtensions
                 stream.Write('\\').Write(')');
             else if (c == '\\')
                 stream.Write('\\').Write('\\');
-            else if (c > 0x7F && c < 0x200)
-                stream.Write('\\').Write(_toOctal(c));
+            else if (c > 0x7F && c <= 0xFF)
+            {
+                var octal = _toOctal(c);
+                _ = octal switch
+                {
+                    < 10 => stream.Write('\\').Write('0').Write('0').Write(octal),
+                    < 100 => stream.Write('\\').Write('0').Write(octal),
+                    _ => stream.Write('\\').Write(octal)
+                };
+            }
             else if (c <= 0x7F)
                 stream.Write(c);
             else

--- a/src/Synercoding.FileFormats.Pdf/LowLevel/ObjectStream.cs
+++ b/src/Synercoding.FileFormats.Pdf/LowLevel/ObjectStream.cs
@@ -121,6 +121,7 @@ internal class ObjectStream
                 .WriteIfNotNull(PdfName.Get("CropBox"), page.CropBox)
                 .WriteIfNotNull(PdfName.Get("BleedBox"), page.BleedBox)
                 .WriteIfNotNull(PdfName.Get("TrimBox"), page.TrimBox)
+                .WriteIfNotNull(PdfName.Get("ArtBox"), page.ArtBox)
                 .WriteIfNotNull(PdfName.Get("Rotate"), (int?)page.Rotation);
 
             // Resources

--- a/src/Synercoding.FileFormats.Pdf/LowLevel/PdfName.cs
+++ b/src/Synercoding.FileFormats.Pdf/LowLevel/PdfName.cs
@@ -93,25 +93,13 @@ public class PdfName
             // 0xff because only ascii is supported in pdf names
             var encoded = c switch
             {
-                // Pdf reserved characters
-                ' ' => "#20",
-                '#' => "#23",
-                '%' => "#25",
-                '(' => "#28",
-                ')' => "#29",
-                '/' => "#2f",
-                '<' => "#3c",
-                '>' => "#3e",
-                '[' => "#5b",
-                ']' => "#5d",
-                '{' => "#7b",
-                '}' => "#7d",
+                (char)0 => throw new InvalidOperationException("NULL character is not allowed in a pdf name."),
+                var cc when cc >= 'a' && cc <= 'z' => cc.ToString(),
+                var cc when cc >= 'A' && cc <= 'Z' => cc.ToString(),
+                var cc when cc >= '0' && cc <= '9' => cc.ToString(),
                 // special characters
                 var cc when cc < 16 => $"#0{Convert.ToString(cc, 16)}",
-                var cc when cc < 32 => '#' + Convert.ToString(cc, 16),
-                var cc when cc > 126 => '#' + Convert.ToString(cc, 16),
-                // "readable characters"
-                var cc => cc.ToString()
+                var cc => '#' + Convert.ToString(cc, 16),
             };
             pdfName.Append(encoded);
         }

--- a/src/Synercoding.FileFormats.Pdf/PackageDetails.props
+++ b/src/Synercoding.FileFormats.Pdf/PackageDetails.props
@@ -10,7 +10,7 @@
     <Product>Synercoding.FileFormats.Pdf</Product>
     <Title>Synercoding.FileFormats.Pdf</Title>
     <Description>Contains classes which makes it easy to quickly create a pdf file.</Description>
-    <PackageReleaseNotes>Rewritten most of the API surface to provide a uniform way to interact with the content.</PackageReleaseNotes>
+    <PackageReleaseNotes>A fix with octal literal string encoding, and rewritten pdfname encoding, renamed art to artbox, and encoded artbox in resulting pdf.</PackageReleaseNotes>
   </PropertyGroup>
 
 </Project>

--- a/src/Synercoding.FileFormats.Pdf/PdfPage.cs
+++ b/src/Synercoding.FileFormats.Pdf/PdfPage.cs
@@ -88,7 +88,7 @@ public sealed class PdfPage : IDisposable
     /// <summary>
     /// The art box of the <see cref="PdfPage"/>
     /// </summary>
-    public Rectangle? Art { get; set; }
+    public Rectangle? ArtBox { get; set; }
 
     /// <inheritdoc />
     public void Dispose()


### PR DESCRIPTION
A fix with octal literal string encoding, and rewritten pdfname encoding, renamed art to artbox, and encoded artbox in resulting pdf.