### PR TITLE
Replace deflate with zlibstream

### DIFF
--- a/src/Synercoding.FileFormats.Pdf/PackageDetails.props
+++ b/src/Synercoding.FileFormats.Pdf/PackageDetails.props
@@ -10,7 +10,7 @@
     <Product>Synercoding.FileFormats.Pdf</Product>
     <Title>Synercoding.FileFormats.Pdf</Title>
     <Description>Contains classes which makes it easy to quickly create a pdf file.</Description>
-    <PackageReleaseNotes>Added transparent and separation images support. Content streams will be flatedecode encoded. And overprint mode support is added.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed broken zlib stream by removing explicit header and replacing deflate with zlib.</PackageReleaseNotes>
   </PropertyGroup>
 
 </Project>

--- a/src/Synercoding.FileFormats.Pdf/PdfWriter.cs
+++ b/src/Synercoding.FileFormats.Pdf/PdfWriter.cs
@@ -275,13 +275,10 @@ public sealed class PdfWriter : IDisposable
     {
         var outputStream = new MemoryStream();
 
-        outputStream.WriteByte(0x78);
-        outputStream.WriteByte(0xDA);
-
         inputStream.Position = 0;
-        using (var flateStream = new DeflateStream(outputStream, CompressionLevel.SmallestSize, true))
+        using (var zlibStream = new ZLibStream(outputStream, CompressionLevel.SmallestSize, true))
         {
-            inputStream.CopyTo(flateStream);
+            inputStream.CopyTo(zlibStream);
         }
 
         outputStream.Position = 0;


### PR DESCRIPTION
Fixed broken zlib stream by removing explicit header and replacing deflate with zlib.