### PR TITLE
Add SourceLink, improve metadata & docs

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -42,7 +42,7 @@ jobs:
         run: dotnet test -c Release
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
-        run: dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:SymbolPackageFormat=snupkg -p:PackageVersion=1.0.0-pre.$GITHUB_RUN_ID src/$PROJECT_NAME/$PROJECT_NAME.*proj
+        run: dotnet pack -v normal -c Release --no-restore --include-symbols -p:SymbolPackageFormat=snupkg -p:PackageVersion=1.0.0-pre.$GITHUB_RUN_ID src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Upload Artifact
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
@@ -82,7 +82,7 @@ jobs:
           echo Version: $VERSION
           VERSION="${VERSION//v}"
           echo Clean Version: $VERSION
-          dotnet pack -v normal -c Release --include-symbols --include-source -p:SymbolPackageFormat=snupkg -p:PackageVersion=$VERSION -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
+          dotnet pack -v normal -c Release --include-symbols -p:SymbolPackageFormat=snupkg -p:PackageVersion=$VERSION -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Publish Nuget to GitHub registry
         run: dotnet nuget push ./nupkg/*.nupkg -k ${GITHUB_TOKEN} -s ${GITHUB_FEED} --skip-duplicate
         env:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,6 +34,9 @@
     <OverwriteReadOnlyFiles>true</OverwriteReadOnlyFiles>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/synercoder/FileFormats.Pdf/</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/synercoder/FileFormats.Pdf</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
     </RestoreSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,10 @@
     </RestoreSources>
   </PropertyGroup>
 
+  <ItemGroup Label="Build packages">
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
+  </ItemGroup>
+
   <ItemGroup Label="General packages">
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="Synercoding.Primitives" Version="1.0.0-rc11" />

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [nuget-badge]: https://img.shields.io/nuget/v/Synercoding.FileFormats.Pdf.svg?label=Synercoding.FileFormats.Pdf
 
 
-This project was created to enable PDF creation on .NETStandard 2.1, .NET 6 & .NET 7. This because multiple libraries did not suit my purpose of working on .NET Core & .NET Framework the same way. Some alternatives supported settings the different boxes (Media, Crop, Bleed & Trim) but did not fully supported images on all platforms. Others supported images but not the different boxes, and again others did not work at all on .NET Core.
+This project was created to enable PDF creation on .NET. Multiple libraries did not suit my purpose of working on .NET Core & .NET Framework the same way. Some alternatives supported settings the different boxes (Media, Crop, Bleed & Trim) but did not fully support images on all platforms. Others supported images but not the different boxes, and again others did not work at all on .NET Core.
 
-Because of those reasons this libary was created. Since then this project has evolved to keep current with the latest versions. Currently only supporting .NET 8.0 and .NET 10.0.
+Because of those reasons this library was created. Since then this project has evolved to keep current with the latest versions. Currently targeting .NET 8.0 and .NET 10.0.
 
 ## License
 This project is licensed under a dual license. See [LICENSE](LICENSE) for full information. It comes down to: Apache License 2.0 for small and non-profit companies, or contact me for other options.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,10 @@
 
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(Configuration)'=='RELEASE'">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Synercoding.FileFormats.Pdf/PackageDetails.props
+++ b/src/Synercoding.FileFormats.Pdf/PackageDetails.props
@@ -11,6 +11,11 @@
     <Title>Synercoding.FileFormats.Pdf</Title>
     <Description>Contains classes which makes it easy to quickly create a pdf file.</Description>
     <PackageReleaseNotes>Complete rewrite to add support for fonts, and with an read/edit future in mind.</PackageReleaseNotes>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update packaging: add SourceLink, improve metadata & docs (https://github.com/synercoder/FileFormats.Pdf/pull/82)
- Switch to Microsoft.SourceLink.GitHub for source linking; remove --include-source from dotnet pack.
- Add repository/source link metadata and embed untracked sources for better debugging.
- Include README.md in NuGet package and update package metadata.
- Clarify and update targeted .NET versions in README.